### PR TITLE
Serve static build under subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Docker
 
+The provided Dockerfile builds the Angular app with a base href of `/smart-city-urban-heat-monitoring/` and serves the compiled files with Nginx.
 To run the application with Docker, use the included Compose file:
 
 ```
 docker compose up --build
 ```
 
-The app will be available at `http://localhost:4200/`.
+The app will be available at `http://localhost:4200/smart-city-urban-heat-monitoring/`.
 
 ## Development server
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,4 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "4200:4200"
-    volumes:
-      - ./src:/app/src
-    environment:
-      - NODE_ENV=production
+      - "4200:80"


### PR DESCRIPTION
## Summary
- Build Angular app with `/smart-city-urban-heat-monitoring/` base href and serve via Nginx
- Update docker-compose to expose container port 80 on host 4200
- Document new Docker workflow and access path

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run build -- --configuration production --base-href /smart-city-urban-heat-monitoring/`


------
https://chatgpt.com/codex/tasks/task_e_68ad65989bcc832a8e3760b37f1e963b