### PR TITLE
Replace Nginx with Caddy as reverse proxy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,5 @@
+:80 {
+    root * /usr/share/caddy
+    try_files {path} /smart-city-urban-heat-monitoring/index.html
+    file_server
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,13 @@ RUN npm ci
 COPY . .
 RUN npm run build -- --configuration production --base-href /smart-city-urban-heat-monitoring/
 
-# Stage 2: Serve app with Nginx
-FROM nginx:alpine
-COPY --from=build /app/dist/smart-city-urban-heat-monitoring /usr/share/nginx/html/smart-city-urban-heat-monitoring
+# Stage 2: Serve app with Caddy
+FROM caddy:alpine
+
+# Copy Caddy configuration
+COPY Caddyfile /etc/caddy/Caddyfile
+
+# Copy built Angular files to Caddy's web root
+COPY --from=build /app/dist/smart-city-urban-heat-monitoring /usr/share/caddy/smart-city-urban-heat-monitoring
+
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Docker
 
-The provided Dockerfile builds the Angular app with a base href of `/smart-city-urban-heat-monitoring/` and serves the compiled files with Nginx.
+The provided Dockerfile builds the Angular app with a base href of `/smart-city-urban-heat-monitoring/` and serves the compiled files using [Caddy](https://caddyserver.com) as a reverse proxy.
 To run the application with Docker, use the included Compose file:
 
 ```


### PR DESCRIPTION
## Summary
- Serve production build with Caddy instead of Nginx
- Add Caddyfile for SPA routing
- Document Caddy-based setup

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ad684be81c832a93c64c897d70401d