### PR TITLE
Rename app to Smart City Urban Heat Monitoring

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -10,7 +10,7 @@
 
 :80 {
   handle {
-    reverse_proxy heat-monitoring-app:4200
+    reverse_proxy smart-city-urban-heat-monitoring:4200
   }
 }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile.angular
+# Dockerfile
 
 # Step 1: Use Node.js image to build and serve Angular App
 FROM node:18 AS angular-build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GesundesTalDemonstrator
+# Smart City Urban Heat Monitoring
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 17.0.8.
 

--- a/angular.json
+++ b/angular.json
@@ -3,7 +3,7 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "gesundes-tal-demonstrator": {
+    "smart-city-urban-heat-monitoring": {
       "projectType": "application",
       "schematics": {},
       "root": "",
@@ -13,7 +13,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "outputPath": "dist/gesundes-tal-demonstrator",
+            "outputPath": "dist/smart-city-urban-heat-monitoring",
             "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
@@ -58,10 +58,10 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {
-              "buildTarget": "gesundes-tal-demonstrator:build:production"
+              "buildTarget": "smart-city-urban-heat-monitoring:build:production"
             },
             "development": {
-              "buildTarget": "gesundes-tal-demonstrator:build:development"
+              "buildTarget": "smart-city-urban-heat-monitoring:build:development"
             }
           },
           "defaultConfiguration": "development"
@@ -69,7 +69,7 @@
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "buildTarget": "gesundes-tal-demonstrator:build"
+            "buildTarget": "smart-city-urban-heat-monitoring:build"
           }
         },
         "test": {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,10 @@
 version: '3.8'
 
 services:
-  heat-monitoring-app:
+  smart-city-urban-heat-monitoring:
     build:
       context: .
-      dockerfile: Dockerfile.angular
+      dockerfile: Dockerfile
     ports:
       - "4200:4200"
     volumes:
@@ -14,7 +14,7 @@ services:
 
   caddy:
     image: caddy:2
-    container_name: reverse_proxy_heat_monitoring_app
+    container_name: reverse_proxy_smart_city_urban_heat_monitoring
     ports:
       - "80:80"
     volumes:
@@ -22,7 +22,7 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
-      - heat-monitoring-app
+      - smart-city-urban-heat-monitoring
 
 volumes:
   caddy_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "gesundes-tal-demonstrator",
+  "name": "smart-city-urban-heat-monitoring",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "gesundes-tal-demonstrator",
+      "name": "smart-city-urban-heat-monitoring",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gesundes-tal-demonstrator",
+  "name": "smart-city-urban-heat-monitoring",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -14,16 +14,16 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'gesundes-tal-demonstrator' title`, () => {
+  it(`should have the 'smart-city-urban-heat-monitoring' title`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('gesundes-tal-demonstrator');
+    expect(app.title).toEqual('smart-city-urban-heat-monitoring');
   });
 
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, gesundes-tal-demonstrator');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, smart-city-urban-heat-monitoring');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,5 +12,5 @@ import { HttpClientModule } from '@angular/common/http';
   styleUrl: './app.component.css'
 })
 export class AppComponent {
-  title = 'gesundes-tal-demonstrator';
+  title = 'smart-city-urban-heat-monitoring';
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Urban Heat Monitoring</title>
+  <title>Smart City Urban Heat Monitoring</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">


### PR DESCRIPTION
## Summary
- rename project and service identifiers from 'GesundesTalDemonstrator' and 'heat-monitoring-app' to 'smart-city-urban-heat-monitoring'
- replace Dockerfile.angular with Dockerfile and update docker-compose and Caddy proxy targets
- update documentation and page title to Smart City Urban Heat Monitoring

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad7d4cbd18832a80245549ead9bde8