### PR TITLE
Serve Angular app from /smart-city-urban-heat-monitoring/

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -9,7 +9,13 @@
 # domain name.
 
 :80 {
-  handle {
+  # Redirect root requests to the Angular application base path
+  handle / {
+    redir /smart-city-urban-heat-monitoring/
+  }
+
+  # Proxy all requests under the base path to the Angular container
+  handle_path /smart-city-urban-heat-monitoring/* {
     reverse_proxy smart-city-urban-heat-monitoring:4200
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,37 @@
 # Dockerfile
 
-# Step 1: Use Node.js image to build and serve Angular App
-FROM node:18 AS angular-build
+# Stage 1: Build the Angular application
+FROM node:18 AS build
 
 # Set working directory inside the container
 WORKDIR /app
 
-# Copy Angular project files into the container
-COPY . .
-
-# Install Angular dependencies
-RUN npm install
+# Install dependencies based on the lock file for reproducible builds
+COPY package*.json ./
+RUN npm ci
 
 # Install Angular CLI globally
 RUN npm install -g @angular/cli
 
-# Build the Angular application for production
-RUN npm run build --prod
+# Copy the rest of the project files
+COPY . .
 
-# Expose the port for the Angular app (default is 4200 for ng serve)
+# Build the Angular app with the configured base href
+RUN ng build --configuration production --base-href /smart-city-urban-heat-monitoring/
+
+# Stage 2: Serve the built application
+FROM node:18-alpine AS runtime
+WORKDIR /usr/share/app
+
+# Copy built files from the previous stage
+COPY --from=build /app/dist/smart-city-urban-heat-monitoring ./
+
+# Install a simple HTTP server to serve static content
+RUN npm install -g http-server
+
+# Expose the port used by the HTTP server
 EXPOSE 4200
 
-# Serve the Angular application
-CMD ["ng", "serve", "--host", "0.0.0.0", "--port", "4200"]
+# Run the HTTP server
+CMD ["http-server", ".", "-p", "4200"]
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,8 +7,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - "4200:4200"
-    volumes:
-      - ./src:/app/src
     environment:
       - NODE_ENV=production
 


### PR DESCRIPTION
## Summary
- build Angular app in Docker with base href `/smart-city-urban-heat-monitoring/` and serve static files via `http-server`
- update Caddy to forward `/smart-city-urban-heat-monitoring/` and redirect root
- simplify compose setup for production

## Testing
- `npm run build -- --base-href /smart-city-urban-heat-monitoring/`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `docker compose build smart-city-urban-heat-monitoring` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8b8c8544832ab71fc4223459c851