### PR TITLE
Fix Caddy root redirect syntax

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -10,9 +10,7 @@
 
 :80 {
   # Redirect root requests to the Angular application base path
-  handle / {
-    redir /smart-city-urban-heat-monitoring/
-  }
+  redir / /smart-city-urban-heat-monitoring/
 
   # Proxy all requests under the base path to the Angular container
   handle_path /smart-city-urban-heat-monitoring/* {


### PR DESCRIPTION
## Summary
- correct Caddy redirect to root base path using `redir`

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8d247808832abcc1ae1abf3a99ce