### PR TITLE
Simplify Docker setup to run Angular app directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
 
+## Docker
+
+Build and run the application in a container on port 4200 using Docker Compose:
+
+```
+docker-compose up -d --build
+```
+
+After the command completes, open [http://localhost:4200](http://localhost:4200) to access the application.
+
 ## Code scaffolding
 
 Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,17 +1,13 @@
 version: '3.8'
 
 services:
-  caddy:
-    volumes:
-      - ./Caddyfile.local:/etc/caddy/Caddyfile
-
-# Optional: python-weather für dev aktivieren
-#  python-weather:
-#    build:
-#      context: .
-#      dockerfile: Dockerfile.python
-#    volumes:
-#      - ./src:/app/src
-#    environment:
-#      - API_KEY=dev-test-key
-#    tty: true
+  # Optional: python-weather für dev aktivieren
+  # python-weather:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile.python
+  #   volumes:
+  #     - ./src:/app/src
+  #   environment:
+  #     - API_KEY=dev-test-key
+  #   tty: true

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,19 +1,13 @@
 version: '3.8'
 
 services:
-  caddy:
-    ports:
-      - "443:443"
-    volumes:
-      - ./Caddyfile.prod:/etc/caddy/Caddyfile
-
-# Optional: python-weather für prod aktivieren
-#  python-weather:
-#    build:
-#      context: .
-#      dockerfile: Dockerfile.python
-#    volumes:
-#      - ./src:/app/src
-#    environment:
-#      - API_KEY=b46ba223dfe6adc962f8dc2c94ce7f2a
-#    tty: true
+  # Optional: python-weather für prod aktivieren
+  # python-weather:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile.python
+  #   volumes:
+  #     - ./src:/app/src
+  #   environment:
+  #     - API_KEY=b46ba223dfe6adc962f8dc2c94ce7f2a
+  #   tty: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,19 +11,3 @@ services:
       - ./src:/app/src
     environment:
       - NODE_ENV=production
-
-  caddy:
-    image: caddy:2
-    container_name: reverse_proxy_heat_monitoring_app
-    ports:
-      - "80:80"
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
-      - caddy_data:/data
-      - caddy_config:/config
-    depends_on:
-      - heat-monitoring-app
-
-volumes:
-  caddy_data:
-  caddy_config:


### PR DESCRIPTION
## Summary
- remove Caddy service from compose files so only Angular container runs
- document how to start the app on port 4200 with docker-compose

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad9bf13a20832aaf4369e67f434ce4