### PR TITLE
Remove Caddy from default docker-compose configuration

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,17 +1,13 @@
 version: '3.8'
 
 services:
-  caddy:
-    volumes:
-      - ./Caddyfile.local:/etc/caddy/Caddyfile
-
-# Optional: python-weather für dev aktivieren
-#  python-weather:
-#    build:
-#      context: .
-#      dockerfile: Dockerfile.python
-#    volumes:
-#      - ./src:/app/src
-#    environment:
-#      - API_KEY=dev-test-key
-#    tty: true
+  # Optional: python-weather für dev aktivieren
+  # python-weather:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile.python
+  #   volumes:
+  #     - ./src:/app/src
+  #   environment:
+  #     - API_KEY=dev-test-key
+  #   tty: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,19 +11,3 @@ services:
       - ./src:/app/src
     environment:
       - NODE_ENV=production
-
-  caddy:
-    image: caddy:2
-    container_name: reverse_proxy_heat_monitoring_app
-    ports:
-      - "80:80"
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
-      - caddy_data:/data
-      - caddy_config:/config
-    depends_on:
-      - heat-monitoring-app
-
-volumes:
-  caddy_data:
-  caddy_config:


### PR DESCRIPTION
## Summary
- Drop Caddy reverse proxy from the default docker-compose setup
- Clean the development override compose file by removing Caddy service definition

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9d561d0c832a9cfd5ae002793d07