### PR TITLE
Configure base path for proxied Angular deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ To run the application with Docker, use the included Compose file:
 docker compose up --build
 ```
 
-The app will be available at `http://localhost:4200/`.
+The app will be available at `http://localhost:4200/smart-city-urban-heat-monitoring/`.
 
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+Run `ng serve` for a dev server. Navigate to `http://localhost:4200/smart-city-urban-heat-monitoring/`. The application will automatically reload if you change any of the source files.
 
 ## Code scaffolding
 
@@ -23,7 +23,7 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory and are served under the `/smart-city-urban-heat-monitoring/` path.
 
 ## Running unit tests
 

--- a/angular.json
+++ b/angular.json
@@ -56,6 +56,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "servePath": "/smart-city-urban-heat-monitoring"
+          },
           "configurations": {
             "production": {
               "buildTarget": "smart-city-urban-heat-monitoring:build:production"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
+    "start": "ng serve --base-href /smart-city-urban-heat-monitoring/",
+    "build": "ng build --base-href /smart-city-urban-heat-monitoring/",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },


### PR DESCRIPTION
## Summary
- ensure dev server listens under `/smart-city-urban-heat-monitoring`
- add `--base-href` to default build and serve scripts
- document new application URL

## Testing
- `npm run build -- --configuration=development`
- `CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68adabee6edc832aa8c5a48d9ae58d54